### PR TITLE
Fixed saving user or role restrictions on paged / search site

### DIFF
--- a/restrict-taxonomies.php
+++ b/restrict-taxonomies.php
@@ -342,9 +342,28 @@ class RestrictTaxonomies{
 		{
 			case 'RestrictTaxs_user_options' :
 				$options = get_option( 'RestrictTaxs_user_options' );
+				// Replace options with new values
+				$replacements = array_replace_recursive( $options, $input );			
+				// Fix restrictions (duplicate RestrictCategoriesDefault)
+				foreach ( $replacements as $tax => $replace ) {
+					foreach ( $replace as $user => $restrictions ) {
+						$input[$tax][$user] = array_unique( $restrictions );
+					}
+				}
 				break;
 			case 'RestrictTaxs_options' :
 				$options = get_option( 'RestrictTaxs_options' );
+				// Replace options with new values
+				$replacements = array_replace_recursive( $options, $input );			
+				// Fix restrictions (duplicate RestrictCategoriesDefault)
+				foreach ( $replacements as $tax => $replace ) {
+					foreach ( $replace as $role => $restrictions ) {
+						$input[$tax][$role] = array_unique( $restrictions );
+					}
+				}
+				break;
+			case 'RestrictTaxs_general_options' :
+				$options = get_option( 'RestrictTaxs_general_options' );
 				break;
 			case 'RestrictTaxs_post_type_options' :
 				$options = get_option( 'RestrictTaxs_post_type_options' );


### PR DESCRIPTION
This first gets the saved restrictions, then merges them with array_replace_recursive and cleans out the duplicates. With this fix, saving user restrictions of a searched user works or a paged user/role page without loosing the other restrictions.
