### PR TITLE
Fix for selecting all taxonomy terms for multiple taxonomies

### DIFF
--- a/js/restrict-taxonomies.js
+++ b/js/restrict-taxonomies.js
@@ -3,8 +3,7 @@ jQuery(document).ready(function($) {
 	$( '.select-all' ).click( function( e ) {
 		e.preventDefault();
 		
-		var active_panel = $( this ).closest( 'div' ).find( '.tabs-panel-active' ).attr( 'id' ),
-			items = $( '#' + active_panel + ' input[type="checkbox"]:visible' );
+		items = $( this ).closest( 'div' ).find('.tabs-panel-active input[type="checkbox"]:visible');
 		
 		if ( items.length === items.filter( ':checked' ).length )
 			items.removeAttr( 'checked' );


### PR DESCRIPTION
The old version was only working with the taxonomy "categories". Wherever you clicked, only categories were changing.
