### PR TITLE
Fix selected categories for roles

### DIFF
--- a/restrict-taxonomies.php
+++ b/restrict-taxonomies.php
@@ -667,7 +667,7 @@ class RestrictTaxonomies{
 			else {
 				foreach ( $user_cap as $key ) {
 					// Make sure the settings from the DB isn't empty before building the category list
-					if ( is_array( $settings ) && array_key_exists( $taxonomy,$settings ) && array_key_exists( $key . '_cats', $settings_user[$taxonomy] ) ) {
+					if ( is_array( $settings ) && array_key_exists( $taxonomy,$settings ) && array_key_exists( $key . '_cats', $settings[$taxonomy] ) ) {
 						// Strip out the placeholder category, which is only used to make sure the checkboxes work
 						$settings[$taxonomy][ $key . '_cats' ] = array_values( array_diff( $settings[$taxonomy][ $key . '_cats' ], $defaults ) );
 


### PR DESCRIPTION
In v1.3.2, a bug was introduced that broke selected categories for roles.

Looks like there was a typo in commit 94f0140:
https://github.com/Sladix/Restrict-Taxonomies/commit/94f014016a2f6f658858aebe70fcfd9f4fd5da55#diff-8a0da5d9746ce0709f812b191b134f1dL732

I've fixed this in the PR.  Let me know if you have any questions.